### PR TITLE
fix get_login_info

### DIFF
--- a/Lagrange.Core/Internal/Context/PMHQContext.cs
+++ b/Lagrange.Core/Internal/Context/PMHQContext.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Lagrange.Core.Common;
+using Lagrange.Core.Internal.Event.System;
 using Lagrange.Core.Internal.Packets;
 using Lagrange.Core.Utility.Extension;
 using Lagrange.Core.Utility.Network;
@@ -84,6 +85,20 @@ internal class PMHQContext : ContextBase
         {
             Collection.Keystore.Uin = uint.Parse(response.Data.Result.Uin);
             Collection.Keystore.Uid = response.Data.Result.Uid;
+            var events = Collection.Business.SendEvent(FetchUserInfoEvent.Create(Collection.Keystore.Uin)).Result;
+            if (events.Count != 0 && events[0] is FetchUserInfoEvent { } @event)
+            {
+                Collection.Keystore.Info = new BotKeystore.BotInfo
+                {
+                    Name = @event.UserInfo.Nickname,
+                    Age = (byte)@event.UserInfo.Age,
+                    Gender = (byte)@event.UserInfo.Gender
+                };
+            }
+            else
+            {
+                Collection.Log.LogWarning(Tag, "Get BotInfo Failed");
+            }
         }
     }
 


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在获取自身信息时，获取并存储机器人的昵称、年龄和性别。

增强功能：
- 使用 `FetchUserInfoEvent` 在 `getSelfInfo` 中检索额外的机器人详细信息（昵称、年龄、性别）。
- 将检索到的详细信息存储在机器人的密钥库中。
- 如果获取额外的机器人信息失败，则记录警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fetch and store the bot's nickname, age, and gender during self-info retrieval.

Enhancements:
- Retrieve additional bot details (nickname, age, gender) using `FetchUserInfoEvent` within `getSelfInfo`.
- Store the retrieved details in the bot's keystore.
- Log a warning if fetching additional bot information fails.

</details>